### PR TITLE
Changed Telemetry to Singleton

### DIFF
--- a/account/src/Revature.Account.Api/Startup.cs
+++ b/account/src/Revature.Account.Api/Startup.cs
@@ -57,7 +57,7 @@ namespace Revature.Account.Api
       services.AddScoped<IGenericRepository, GenericRepository>();
       services.AddTransient<IOktaHelperFactory, OktaHelperFactory>();
       services.AddSingleton<IAuthorizationHandler, RoleRequirementHandler>();
-      services.AddScoped<ITelemetryInitializer, AccountTelemetryInitializer>();
+      services.AddSingleton<ITelemetryInitializer, AccountTelemetryInitializer>();
 
       services.AddSwaggerGen(c =>
       {

--- a/address/src/Revature.Address.Api/Startup.cs
+++ b/address/src/Revature.Address.Api/Startup.cs
@@ -61,7 +61,7 @@ namespace Revature.Address.Api
       services.AddApplicationInsightsTelemetry();
       
       services.AddHealthChecks();
-      services.AddScoped<ITelemetryInitializer, AddressTelemetryInitializer>();
+      services.AddSingleton<ITelemetryInitializer, AddressTelemetryInitializer>();
 
       services.AddControllers();
     }

--- a/complex/src/Revature.Complex.Api/Startup.cs
+++ b/complex/src/Revature.Complex.Api/Startup.cs
@@ -78,7 +78,7 @@ namespace Revature.Complex.Api
       // services.AddScoped<IRoomServiceSender, RoomServiceSender>();
       services.AddHttpClient<IAddressRequest, AddressRequest>();
       services.AddHttpClient<IRoomRequest, RoomRequest>();
-      services.AddScoped<ITelemetryInitializer, ComplexTelemetryInitializer>();
+      services.AddSingleton<ITelemetryInitializer, ComplexTelemetryInitializer>();
 
       services.AddAuthentication(options => 
           {

--- a/room/src/Revature.Room.Api/Startup.cs
+++ b/room/src/Revature.Room.Api/Startup.cs
@@ -64,7 +64,7 @@ namespace Revature.Room.Api
       // The following line enables Application Insights telemetry collection.
       services.AddApplicationInsightsTelemetry();
 
-      services.AddScoped<ITelemetryInitializer, RoomTelemetryInitializer>();
+      services.AddSingleton<ITelemetryInitializer, RoomTelemetryInitializer>();
 
       services.AddHealthChecks();
 

--- a/tenant/src/Revature.Tenant.Api/Startup.cs
+++ b/tenant/src/Revature.Tenant.Api/Startup.cs
@@ -68,7 +68,7 @@ namespace Revature.Tenant.Api
       services.AddScoped<ITenantRoomRepository, TenantRoomRepository>();
       services.AddScoped<IMapper, Mapper>();
       services.AddScoped<IServiceBusSender, ServiceBusSender>();
-      services.AddScoped<ITelemetryInitializer, TenantTelemetryInitializer>();
+      services.AddSingleton<ITelemetryInitializer, TenantTelemetryInitializer>();
 
       services.AddHttpClient<IAddressService, AddressService>();
 


### PR DESCRIPTION
<!-- alpine :: pull_request -->

# Bug Fix

## change proposal

Inform us of the changes that will be applied with this pull request.

- [ ] _add ..._
- [ ] _fix
Changed telemetry in the 2 services that aren't being modified to be singleton
  APIs were crashing on startup with scoped telemetry because it was being injected into singleton services
  The singleton consuming telemetry and causing the error is `Microsoft.Extensions.Options.IConfigureOptions`

## reviewer

@fredbelotte @escalonn @kaurrevature 

## contributing

this project is maintained under the terms of the [Contribution Guidelines][contributing].

[contributing]: https://github.com/fredbelotte/alpine/blob/master/.github/CONTRIBUTING.md 'contribution guidelines'
