### PR TITLE
Fixed search to ignore null values rather than filter only if null

### DIFF
--- a/tenant/src/Revature.Tenant.Api/Controllers/TenantController.cs
+++ b/tenant/src/Revature.Tenant.Api/Controllers/TenantController.cs
@@ -39,7 +39,7 @@ namespace Revature.Tenant.Api.Controllers
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<IEnumerable<ApiTenant>>> GetAllAsync([FromQuery] string firstName = null, [FromQuery] string lastName = null, [FromQuery] string gender = null, [FromQuery] string trainingCenter = null)
+    public async Task<ActionResult<IEnumerable<ApiTenant>>> GetAllAsync([FromQuery] string firstName = null, [FromQuery] string lastName = null, [FromQuery] string gender = null, [FromQuery] string trainingCenter = null, [FromQuery] string email = null)
     {
       //Parse training center string to guid if it exists
       Guid? trainingCenterGuid;
@@ -50,7 +50,7 @@ namespace Revature.Tenant.Api.Controllers
 
       //Call repository GetAllAsync
       _logger.LogInformation("GET - Getting tenants");
-      var tenants = await _tenantRepository.GetAllAsync(firstName, lastName, gender, trainingCenterGuid);
+      var tenants = await _tenantRepository.GetAllAsync(firstName, lastName, gender, trainingCenterGuid, email);
 
       //Maps batches and cars correctly, based on null or not null
       var newTenants = new List<Lib.Models.Tenant>();

--- a/tenant/src/Revature.Tenant.Api/Startup.cs
+++ b/tenant/src/Revature.Tenant.Api/Startup.cs
@@ -68,7 +68,7 @@ namespace Revature.Tenant.Api
       services.AddScoped<ITenantRoomRepository, TenantRoomRepository>();
       services.AddScoped<IMapper, Mapper>();
       services.AddScoped<IServiceBusSender, ServiceBusSender>();
-      services.AddScoped<ITelemetryInitializer, TenantTelemetryInitializer>();
+      services.AddSingleton<ITelemetryInitializer, TenantTelemetryInitializer>();
 
       services.AddHttpClient<IAddressService, AddressService>();
 

--- a/tenant/src/Revature.Tenant.DataAccess/Entities/TenantContext.cs
+++ b/tenant/src/Revature.Tenant.DataAccess/Entities/TenantContext.cs
@@ -17,7 +17,7 @@ namespace Revature.Tenant.DataAccess.Entities
       builder.Entity<Tenant>(entity =>
       {
         entity.HasKey(t => t.Id);
-        entity.Property(t => t.Email).IsRequired();
+        entity.HasIndex(t => t.Email).IsUnique();
         entity.Property(t => t.Gender).IsRequired();
         entity.Property(t => t.FirstName).IsRequired().HasMaxLength(100);
         entity.Property(t => t.LastName).IsRequired().HasMaxLength(100);

--- a/tenant/src/Revature.Tenant.DataAccess/Repository/TenantRepository.cs
+++ b/tenant/src/Revature.Tenant.DataAccess/Repository/TenantRepository.cs
@@ -84,15 +84,15 @@ namespace Revature.Tenant.DataAccess.Repository
         .Include(t => t.Batch)
         .AsNoTracking();
 
-      if (string.IsNullOrEmpty(firstName))
+      if (!string.IsNullOrEmpty(firstName))
       {
         tenants = tenants.Where(t => t.FirstName == firstName);
       }
-      if (string.IsNullOrEmpty(lastName))
+      if (!string.IsNullOrEmpty(lastName))
       {
         tenants = tenants.Where(t => t.LastName == lastName);
       }
-      if (string.IsNullOrEmpty(gender))
+      if (!string.IsNullOrEmpty(gender))
       {
         tenants = tenants.Where(t => t.Gender == gender);
       }

--- a/tenant/src/Revature.Tenant.DataAccess/Repository/TenantRepository.cs
+++ b/tenant/src/Revature.Tenant.DataAccess/Repository/TenantRepository.cs
@@ -77,34 +77,36 @@ namespace Revature.Tenant.DataAccess.Repository
     /// Gets a list of all tenants
     /// </summary>
     /// <returns>The collection of all tenants, including their Car and Batch, if applicable</returns>
-    public async Task<ICollection<Lib.Models.Tenant>> GetAllAsync(string firstName = null, string lastName = null, string gender = null, Guid? trainingCenter = null)
+    public async Task<ICollection<Lib.Models.Tenant>> GetAllAsync(string firstName = null, string lastName = null, string gender = null, Guid? trainingCenter = null, string email = null)
     {
       var tenants = _context.Tenant
         .Include(t => t.Car)
         .Include(t => t.Batch)
         .AsNoTracking();
 
-      if (!string.IsNullOrEmpty(firstName))
+      if (!string.IsNullOrWhiteSpace(firstName))
       {
-        tenants = tenants.Where(t => t.FirstName == firstName);
+        tenants = tenants.Where(t => t.FirstName.ToLower() == firstName.ToLower());
       }
-      if (!string.IsNullOrEmpty(lastName))
+      if (!string.IsNullOrWhiteSpace(lastName))
       {
-        tenants = tenants.Where(t => t.LastName == lastName);
+        tenants = tenants.Where(t => t.LastName.ToLower() == lastName.ToLower());
       }
-      if (!string.IsNullOrEmpty(gender))
+      if (!string.IsNullOrWhiteSpace(gender))
       {
-        tenants = tenants.Where(t => t.Gender == gender);
+        tenants = tenants.Where(t => t.Gender.ToLower() == gender.ToLower());
       }
       if (trainingCenter != null)
       {
         tenants = tenants.Where(t => t.TrainingCenter == trainingCenter);
       }
+      if (!string.IsNullOrWhiteSpace(email))
+      {
+        tenants = tenants.Where(t => t.Email.ToLower() == email.ToLower());
+      }
 
       return (await tenants.ToListAsync()).Select(_mapper.MapTenant).ToList();
     }
-
-
 
     /// <summary>
     /// Gets all batches in a training center

--- a/tenant/src/Revature.Tenant.Lib/Interface/ITenantRepository.cs
+++ b/tenant/src/Revature.Tenant.Lib/Interface/ITenantRepository.cs
@@ -29,7 +29,7 @@ namespace Revature.Tenant.Lib.Interface
     /// Gets a list of all tenants
     /// </summary>
     /// <returns>The collection of all tenants</returns>
-    public Task<ICollection<Models.Tenant>> GetAllAsync(string firstName = null, string lastName = null, string gender = null, Guid? trainingCenter = null);
+    public Task<ICollection<Models.Tenant>> GetAllAsync(string firstName = null, string lastName = null, string gender = null, Guid? trainingCenter = null, string email = null);
 
     /// <summary>
     /// Deletes a tenant using their id.


### PR DESCRIPTION
<!-- alpine :: pull_request -->

# Bug Fix: Tenant Search

## change proposal

Inform us of the changes that will be applied with this pull request.

- [ ] _add
Added email to search all
- [ ] _fix 
Search was inverted, and was only searching with nulls/empties rather than ignoring the terms if null
 Added logical nots to string.IfNullOrEmpty calls
Potential Issues:
 Filtering is case sensitive which points to filtering either happening in C# or db collation being case sensitive

## reviewer

@escalonn @kaurrevature @fredbelotte 

## contributing

this project is maintained under the terms of the [Contribution Guidelines][contributing].

[contributing]: https://github.com/fredbelotte/alpine/blob/master/.github/CONTRIBUTING.md 'contribution guidelines'
